### PR TITLE
Feat: Blog posts connected to fake API

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -36,9 +36,20 @@ const posts = [
   },
 ].map((post, index) => ({ ...post, id: index + 1 }));
 
-export const getPosts = (from = 0, count = 4) => {
-  return [...posts].slice(from, count);
+const API_URL = 'https://dummyjson.com/posts';
+
+export const getPosts = async () => {
+  try {
+    const res = await fetch(`${API_URL}`);
+      const data = await res.json();
+      return data.posts
+  }
+  catch (error){
+    console.log(error)
+    return null
+  }
 };
+
 
 export const getPostById = id => {
   return posts.find(post => Number(post.id) === Number(id));

--- a/src/components/post/post.js
+++ b/src/components/post/post.js
@@ -2,7 +2,7 @@ import './post.css';
 import { getPostImageUrl } from '../../utils/utils';
 
 export const Post = (post, index) => {
-  const {  title, description, img, tags, createdDate } = post;
+  const {  title, body, img, tags, createdDate } = post;
   const imageURL = getPostImageUrl(img);
   const Tag = tag => {
     return `
@@ -14,9 +14,8 @@ export const Post = (post, index) => {
         <img class="post__image" src="${imageURL}" />
 
         <div class="post__content">
-            <p class="post__createDate">${createdDate}</p>
             <h3 class="post__title">${title}</h3>
-            <p class="post__description">${description}</p>
+            <p class="post__description">${body}</p>
             <ul class="post__list">${tags.map(tag => Tag(tag)).join('')}</ul>
             <button class ='post__read-btn'>Read more</button>
         </div>

--- a/src/pages/BlogPostsPage.js
+++ b/src/pages/BlogPostsPage.js
@@ -4,8 +4,8 @@ import { Blog } from '../components/blog/blog';
 import { Pagination } from '../components/pagination';
 import { Layout } from '../layout/Layout';
 
-export const BlogPostsPage = () => {
-  const posts = getPosts();
+export const BlogPostsPage = async () => {
+  const posts = await getPosts();
 
   return Layout(`
     <section class="posts">

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,11 @@ export interface ProductsResponse {
 export interface RatingStar {
   fill: string;
 }
+
+export interface Post {
+  id: number;
+  title: string;
+  body: string;
+  data: string;
+  tags: string[];
+}


### PR DESCRIPTION
all posts (from fake API) loads at one page. Fake API does not nave images so now there only standards blanks images, same with the dates.